### PR TITLE
Move woff2 fonts url before woff

### DIFF
--- a/open-sans.css
+++ b/open-sans.css
@@ -4,8 +4,8 @@
     font-style: normal;
     src: url('./fonts/Light/OpenSans-Light.eot');
     src: url('./fonts/Light/OpenSans-Light.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/Light/OpenSans-Light.woff') format('woff'),
     url('./fonts/Light/OpenSans-Light.woff2') format('woff2'),
+    url('./fonts/Light/OpenSans-Light.woff') format('woff'),
     url('./fonts/Light/OpenSans-Light.ttf') format('truetype'),
     url('./fonts/Light/OpenSans-Light.svg#OpenSansLight') format('svg');
 }
@@ -16,8 +16,8 @@
     font-style: italic;
     src: url('./fonts/LightItalic/OpenSans-LightItalic.eot');
     src: url('./fonts/LightItalic/OpenSans-LightItalic.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/LightItalic/OpenSans-LightItalic.woff') format('woff'),
     url('./fonts/LightItalic/OpenSans-LightItalic.woff2') format('woff2'),
+    url('./fonts/LightItalic/OpenSans-LightItalic.woff') format('woff'),
     url('./fonts/LightItalic/OpenSans-LightItalic.ttf') format('truetype'),
     url('./fonts/LightItalic/OpenSans-LightItalic.svg#OpenSansLightItalic') format('svg');
 }
@@ -28,8 +28,8 @@
     font-style: normal;
     src: url('./fonts/Regular/OpenSans-Regular.eot');
     src: url('./fonts/Regular/OpenSans-Regular.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/Regular/OpenSans-Regular.woff') format('woff'),
     url('./fonts/Regular/OpenSans-Regular.woff2') format('woff2'),
+    url('./fonts/Regular/OpenSans-Regular.woff') format('woff'),
     url('./fonts/Regular/OpenSans-Regular.ttf') format('truetype'),
     url('./fonts/Regular/OpenSans-Regular.svg#OpenSansRegular') format('svg');
 }
@@ -40,8 +40,8 @@
     font-style: italic;
     src: url('./fonts/Italic/OpenSans-Italic.eot');
     src: url('./fonts/Italic/OpenSans-Italic.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/Italic/OpenSans-Italic.woff') format('woff'),
     url('./fonts/Italic/OpenSans-Italic.woff2') format('woff2'),
+    url('./fonts/Italic/OpenSans-Italic.woff') format('woff'),
     url('./fonts/Italic/OpenSans-Italic.ttf') format('truetype'),
     url('./fonts/Italic/OpenSans-Italic.svg#OpenSansItalic') format('svg');
 }
@@ -52,8 +52,8 @@
     font-style: normal;
     src: url('./fonts/Semibold/OpenSans-Semibold.eot');
     src: url('./fonts/Semibold/OpenSans-Semibold.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/Semibold/OpenSans-Semibold.woff') format('woff'),
     url('./fonts/Semibold/OpenSans-Semibold.woff2') format('woff2'),
+    url('./fonts/Semibold/OpenSans-Semibold.woff') format('woff'),
     url('./fonts/Semibold/OpenSans-Semibold.ttf') format('truetype'),
     url('./fonts/Semibold/OpenSans-Semibold.svg#OpenSansSemibold') format('svg');
 }
@@ -64,8 +64,8 @@
     font-style: italic;
     src: url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.eot');
     src: url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
     url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.woff2') format('woff2'),
+    url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
     url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.ttf') format('truetype'),
     url('./fonts/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic') format('svg');
 }
@@ -76,8 +76,8 @@
     font-style: normal;
     src: url('./fonts/Bold/OpenSans-Bold.eot');
     src: url('./fonts/Bold/OpenSans-Bold.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/Bold/OpenSans-Bold.woff') format('woff'),
     url('./fonts/Bold/OpenSans-Bold.woff2') format('woff2'),
+    url('./fonts/Bold/OpenSans-Bold.woff') format('woff'),
     url('./fonts/Bold/OpenSans-Bold.ttf') format('truetype'),
     url('./fonts/Bold/OpenSans-Bold.svg#OpenSansBold') format('svg');
 }
@@ -88,8 +88,8 @@
     font-style: italic;
     src: url('./fonts/BoldItalic/OpenSans-BoldItalic.eot');
     src: url('./fonts/BoldItalic/OpenSans-BoldItalic.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
     url('./fonts/BoldItalic/OpenSans-BoldItalic.woff2') format('woff2'),
+    url('./fonts/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
     url('./fonts/BoldItalic/OpenSans-BoldItalic.ttf') format('truetype'),
     url('./fonts/BoldItalic/OpenSans-BoldItalic.svg#OpenSansBoldItalic') format('svg');
 }
@@ -100,8 +100,8 @@
     font-style: normal;
     src: url('./fonts/ExtraBold/OpenSans-ExtraBold.eot');
     src: url('./fonts/ExtraBold/OpenSans-ExtraBold.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
     url('./fonts/ExtraBold/OpenSans-ExtraBold.woff2') format('woff2'),
+    url('./fonts/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
     url('./fonts/ExtraBold/OpenSans-ExtraBold.ttf') format('truetype'),
     url('./fonts/ExtraBold/OpenSans-ExtraBold.svg#OpenSansExtrabold') format('svg');
 }
@@ -112,8 +112,8 @@
     font-style: italic;
     src: url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot');
     src: url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot?#iefix') format('embedded-opentype'),
-    url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
     url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff2') format('woff2'),
+    url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
     url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf') format('truetype'),
     url('./fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.svg#OpenSansExtraboldItalic') format('svg');
 }

--- a/open-sans.less
+++ b/open-sans.less
@@ -6,8 +6,8 @@
   font-style: normal;
   src: url('@{FontPathOpenSans}/Light/OpenSans-Light.eot');
   src: url('@{FontPathOpenSans}/Light/OpenSans-Light.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/Light/OpenSans-Light.woff') format('woff'),
        url('@{FontPathOpenSans}/Light/OpenSans-Light.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/Light/OpenSans-Light.woff') format('woff'),
        url('@{FontPathOpenSans}/Light/OpenSans-Light.ttf') format('truetype'),
        url('@{FontPathOpenSans}/Light/OpenSans-Light.svg#OpenSansLight') format('svg');
 }
@@ -18,8 +18,8 @@
   font-style: italic;
   src: url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.eot');
   src: url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.ttf') format('truetype'),
        url('@{FontPathOpenSans}/LightItalic/OpenSans-LightItalic.svg#OpenSansLightItalic') format('svg');
 }
@@ -30,8 +30,8 @@
   font-style: normal;
   src: url('@{FontPathOpenSans}/Regular/OpenSans-Regular.eot');
   src: url('@{FontPathOpenSans}/Regular/OpenSans-Regular.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/Regular/OpenSans-Regular.woff') format('woff'),
        url('@{FontPathOpenSans}/Regular/OpenSans-Regular.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/Regular/OpenSans-Regular.woff') format('woff'),
        url('@{FontPathOpenSans}/Regular/OpenSans-Regular.ttf') format('truetype'),
        url('@{FontPathOpenSans}/Regular/OpenSans-Regular.svg#OpenSansRegular') format('svg');
 }
@@ -42,8 +42,8 @@
   font-style: italic;
   src: url('@{FontPathOpenSans}/Italic/OpenSans-Italic.eot');
   src: url('@{FontPathOpenSans}/Italic/OpenSans-Italic.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/Italic/OpenSans-Italic.woff') format('woff'),
        url('@{FontPathOpenSans}/Italic/OpenSans-Italic.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/Italic/OpenSans-Italic.woff') format('woff'),
        url('@{FontPathOpenSans}/Italic/OpenSans-Italic.ttf') format('truetype'),
        url('@{FontPathOpenSans}/Italic/OpenSans-Italic.svg#OpenSansItalic') format('svg');
 }
@@ -54,8 +54,8 @@
   font-style: normal;
   src: url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.eot');
   src: url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.woff') format('woff'),
        url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.woff') format('woff'),
        url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.ttf') format('truetype'),
        url('@{FontPathOpenSans}/Semibold/OpenSans-Semibold.svg#OpenSansSemibold') format('svg');
 }
@@ -66,8 +66,8 @@
   font-style: italic;
   src: url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.eot');
   src: url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.ttf') format('truetype'),
        url('@{FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic') format('svg');
 }
@@ -78,8 +78,8 @@
   font-style: normal;
   src: url('@{FontPathOpenSans}/Bold/OpenSans-Bold.eot');
   src: url('@{FontPathOpenSans}/Bold/OpenSans-Bold.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/Bold/OpenSans-Bold.woff') format('woff'),
        url('@{FontPathOpenSans}/Bold/OpenSans-Bold.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/Bold/OpenSans-Bold.woff') format('woff'),
        url('@{FontPathOpenSans}/Bold/OpenSans-Bold.ttf') format('truetype'),
        url('@{FontPathOpenSans}/Bold/OpenSans-Bold.svg#OpenSansBold') format('svg');
 }
@@ -90,8 +90,8 @@
   font-style: italic;
   src: url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.eot');
   src: url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.ttf') format('truetype'),
        url('@{FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.svg#OpenSansBoldItalic') format('svg');
 }
@@ -102,8 +102,8 @@
   font-style: normal;
   src: url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.eot');
   src: url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
        url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
        url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.ttf') format('truetype'),
        url('@{FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.svg#OpenSansExtrabold') format('svg');
 }
@@ -114,8 +114,8 @@
   font-style: italic;
   src: url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot');
   src: url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot?#iefix') format('embedded-opentype'),
-       url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff2') format('woff2'),
+       url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
        url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf') format('truetype'),
        url('@{FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.svg#OpenSansExtraboldItalic') format('svg');
 }

--- a/open-sans.scss
+++ b/open-sans.scss
@@ -6,8 +6,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: normal;
   src: url('#{$FontPathOpenSans}/Light/OpenSans-Light.eot');
   src: url('#{$FontPathOpenSans}/Light/OpenSans-Light.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/Light/OpenSans-Light.woff') format('woff'),
        url('#{$FontPathOpenSans}/Light/OpenSans-Light.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/Light/OpenSans-Light.woff') format('woff'),
        url('#{$FontPathOpenSans}/Light/OpenSans-Light.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/Light/OpenSans-Light.svg#OpenSansLight') format('svg');
 }
@@ -18,8 +18,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: italic;
   src: url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.eot');
   src: url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.svg#OpenSansLightItalic') format('svg');
 }
@@ -30,8 +30,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: normal;
   src: url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.eot');
   src: url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff') format('woff'),
        url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff') format('woff'),
        url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/Regular/OpenSans-Regular.svg#OpenSansRegular') format('svg');
 }
@@ -42,8 +42,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: italic;
   src: url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.eot');
   src: url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff') format('woff'),
        url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff') format('woff'),
        url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/Italic/OpenSans-Italic.svg#OpenSansItalic') format('svg');
 }
@@ -54,8 +54,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: normal;
   src: url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.eot');
   src: url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff') format('woff'),
        url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff') format('woff'),
        url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.svg#OpenSansSemibold') format('svg');
 }
@@ -66,8 +66,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: italic;
   src: url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.eot');
   src: url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic') format('svg');
 }
@@ -78,8 +78,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: normal;
   src: url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.eot');
   src: url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff') format('woff'),
        url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff') format('woff'),
        url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/Bold/OpenSans-Bold.svg#OpenSansBold') format('svg');
 }
@@ -90,8 +90,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: italic;
   src: url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.eot');
   src: url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.svg#OpenSansBoldItalic') format('svg');
 }
@@ -102,8 +102,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: normal;
   src: url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.eot');
   src: url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
        url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff') format('woff'),
        url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.svg#OpenSansExtrabold') format('svg');
 }
@@ -114,8 +114,8 @@ $FontPathOpenSans: "./fonts" !default;
   font-style: italic;
   src: url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot');
   src: url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.eot?#iefix') format('embedded-opentype'),
-       url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff2') format('woff2'),
+       url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff'),
        url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf') format('truetype'),
        url('#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.svg#OpenSansExtraboldItalic') format('svg');
 }


### PR DESCRIPTION
If WOFF2 fonts declaration in the CSS is after WOFF, it is never chosen by the browser.